### PR TITLE
Skip elements that do not use the validity modifier

### DIFF
--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -1,5 +1,5 @@
 import { modifier } from 'ember-modifier';
-import { validate } from 'ember-validity-modifier/utils/validate';
+import { validate, registerValidatable } from 'ember-validity-modifier/utils/validate';
 
 const commaSeperate = s => s.split(',').map(i => i.trim()).filter(Boolean);
 const reduceValidators = async (validators, ...args) => {
@@ -24,6 +24,7 @@ export default modifier(function validity(
   autoValidationEvents.forEach(eventName => {
     element.addEventListener(eventName, autoValidationHandler);
   });
+  registerValidatable(element);
   return () => {
     element.removeEventListener('validate', validateHandler);
     autoValidationEvents.forEach(eventName => {

--- a/addon/utils/validate.js
+++ b/addon/utils/validate.js
@@ -1,4 +1,7 @@
+const validatables = new WeakSet();
+
 function validateElement(element) {
+  if (!isValidatable(element)) { return; }
   let validateEvent = new CustomEvent('validate');
   return new Promise(resolve => {
     let handler = () => {
@@ -12,4 +15,12 @@ function validateElement(element) {
 
 export function validate(...elements) {
   return Promise.all(elements.map(validateElement));
+}
+
+export function registerValidatable(element) {
+  validatables.add(element);
+}
+
+export function isValidatable(element) {
+  return validatables.has(element);
 }


### PR DESCRIPTION
Prior to this change, validate would expect all elements to trigger the validated event but only elements which have the validity modifier will do this.

This change will only validate elements that have the validity modifier.

Fixes #3