### PR TITLE
on="validator-update"

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ export default class MyForm extends Component {
 }
 ```
 
-#### Example eager validation
+#### Example with `validator-update` event
 
-To validate the form state on initial render and any time its dependent arguments change, use the `eager` option.
+To validate the form state on initial render and any time its dependent arguments change, add the `'validator-update'` event to the list of events passed in via the `on` argument.
 
 ```hbs
-  <input {{validity (fn this.matchTo this.match) on="change" eager=true}}>
+  <input {{validity (fn this.matchTo this.match) on="change,validator-update"}}>
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ export default MyComponent extends Component {
 }
 ```
 
+**Tip:** For Glimmer's tracking to work properly, make sure you reference each tracked property you intend to validate against unconditionally in your validation method.
+
 #### Example with select
 
 ```hbs

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ export default class MyForm extends Component {
 }
 ```
 
+#### Example eager validation
+
+To validate the form state on initial render and any time its dependent arguments change, use the `eager` option.
+
+```hbs
+  <input {{validity (fn this.matchTo this.match) on="change" eager=true}}>
+```
+
+```js
+export default MyComponent extends Component {
+  @action
+  matchTo(match, { value }) {
+    return value === match ? [] : ['Must match exactly'];
+  }
+}
+```
+
 #### Example with select
 
 ```hbs

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -10,7 +10,7 @@ const reduceValidators = async (validators, ...args) => {
 export default modifier(function validity(
   element,
   validators,
-  { on: eventNames = 'change,input,blur', eager = false }
+  { on: eventNames = 'change,input,blur' }
 ) {
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
@@ -21,11 +21,16 @@ export default modifier(function validity(
     element.dispatchEvent(new CustomEvent('validated'));
   };
   element.addEventListener('validate', validateHandler);
+  let watchForValidatorUpdates = false;
   autoValidationEvents.forEach(eventName => {
+    if (eventName === 'validator-update') {
+      watchForValidatorUpdates = true;
+      return;
+    }
     element.addEventListener(eventName, autoValidationHandler);
   });
   registerValidatable(element);
-  if (eager) {
+  if (watchForValidatorUpdates) {
     validate(element);
   }
   return () => {

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -10,7 +10,7 @@ const reduceValidators = async (validators, ...args) => {
 export default modifier(function validity(
   element,
   validators,
-  { on: eventNames = 'change,input,blur' }
+  { on: eventNames = 'change,input,blur', eager = false }
 ) {
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
@@ -25,6 +25,9 @@ export default modifier(function validity(
     element.addEventListener(eventName, autoValidationHandler);
   });
   registerValidatable(element);
+  if (eager) {
+    validate(element);
+  }
   return () => {
     element.removeEventListener('validate', validateHandler);
     autoValidationEvents.forEach(eventName => {

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -122,4 +122,21 @@ module('Integration | Modifier | validity', function(hooks) {
     sinon.assert.calledOnce(this.testValidator);
   });
 
+  test('if eager, validates on initial render', async function() {
+    this.testValidator = sinon.stub().returns([]);
+    await render(hbs`<input {{validity this.testValidator eager=true}}>`);
+    sinon.assert.calledOnce(this.testValidator);
+  });
+
+  test('if eager, validates if arguments change', async function() {
+    this.testValidator = sinon.stub().returns([]);
+    this.set('match', 'foo');
+    await render(hbs`<input {{validity (fn this.testValidator this.match) eager=true}}>`);
+    sinon.assert.calledOnce(this.testValidator);
+    sinon.assert.calledWith(this.testValidator, 'foo');
+    await this.set('match', 'foo-bar');
+    sinon.assert.calledTwice(this.testValidator);
+    sinon.assert.calledWith(this.testValidator, 'foo-bar');
+  });
+
 });

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -122,21 +122,23 @@ module('Integration | Modifier | validity', function(hooks) {
     sinon.assert.calledOnce(this.testValidator);
   });
 
-  test('if eager, validates on initial render', async function() {
+  test('validates on initial render if validator-update is present in list of events', async function() {
     this.testValidator = sinon.stub().returns([]);
-    await render(hbs`<input {{validity this.testValidator eager=true}}>`);
+    await render(hbs`<input {{validity this.testValidator on="validator-update"}}>`);
     sinon.assert.calledOnce(this.testValidator);
   });
 
-  test('if eager, validates if arguments change', async function() {
+  test('validates if validator-update event is present and arguments change', async function() {
     this.testValidator = sinon.stub().returns([]);
     this.set('match', 'foo');
-    await render(hbs`<input {{validity (fn this.testValidator this.match) eager=true}}>`);
+    await render(hbs`<input {{validity (fn this.testValidator this.match) on="validator-update,change"}}>`);
     sinon.assert.calledOnce(this.testValidator);
     sinon.assert.calledWith(this.testValidator, 'foo');
     await this.set('match', 'foo-bar');
     sinon.assert.calledTwice(this.testValidator);
     sinon.assert.calledWith(this.testValidator, 'foo-bar');
+    await fillIn('input', 'foo-bar');
+    sinon.assert.calledThrice(this.testValidator);
   });
 
 });


### PR DESCRIPTION
The eager argument causes the validate modifier to run validation checks on initial render and when any of the arguments it depends on changes. This allows for form elements to update their validation state when the application state changes, in addition to user input.

Included two automated test cases to cover this argument and a sample in the docs. I also have a small test case I wrote in the addon's dummy app in my local Git repo - let me know if you'd like me to add it to this PR as well.

Thanks in advance for your consideration and review!