### PR TITLE
Prevent multiple validation from multiple events

### DIFF
--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -15,10 +15,10 @@ export default modifier(function validity(
   let isValidating = false;
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
-  let validateHandler = async () => {
+  let validateHandler = async (event) => {
     if (isValidating) { return; }
     isValidating = true;
-    let [error = ''] = await reduceValidators(validators, element);
+    let [error = ''] = await reduceValidators(validators, element, event);
     element.checkValidity();
     element.setCustomValidity(error);
     element.dispatchEvent(new CustomEvent('validated'));

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -12,13 +12,17 @@ export default modifier(function validity(
   validators,
   { on: eventNames = 'change,input,blur' }
 ) {
+  let isValidating = false;
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
   let validateHandler = async () => {
+    if (isValidating) { return; }
+    isValidating = true;
     let [error = ''] = await reduceValidators(validators, element);
     element.checkValidity();
     element.setCustomValidity(error);
     element.dispatchEvent(new CustomEvent('validated'));
+    isValidating = false;
   };
   element.addEventListener('validate', validateHandler);
   autoValidationEvents.forEach(eventName => {

--- a/tests/helpers/wait-for-validated.js
+++ b/tests/helpers/wait-for-validated.js
@@ -6,19 +6,19 @@ function createDeferred() {
   return { resolve, promise };
 }
 
+function getDeferred(element) {
+  let deferred = validatables.get(element) ?? createDeferred();
+  validatables.set(element, deferred);
+  return deferred;
+}
+
 export function validatable(element) {
-  element.addEventListener('validated', event => {
-    if (!validatables.has(element)) {
-      validatables.set(element, createDeferred());
-    }
-    validatables.get(element).resolve(event);
-  });
+  let handler = (event) => getDeferred(element).resolve(event);
+  element.addEventListener('validated', handler);
   return element;
 }
 
-export function waitForValidated(element) {
-  if (!validatables.has(element)) {
-    validatables.set(element, createDeferred());
-  }
-  return validatables.get(element).promise;
+export async function waitForValidated(element) {
+  await getDeferred(element).promise;
+  validatables.delete(element);
 }

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -20,6 +20,17 @@ module('Integration | Modifier | validity', function(hooks) {
     assert.strictEqual(subject.validationMessage, '');
   });
 
+  test('multiple validate events only validate once per cycle', async function() {
+    this.testValidator = sinon.stub().returns([]);
+    await render(hbs`<input {{validity this.testValidator on=""}}>`);
+    let subject = validatable(find('input'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    await waitForValidated(subject);
+    sinon.assert.calledOnce(this.testValidator);
+  });
+
   test('multiple validators sets validity to true', async function(assert) {
     this.testValidator = sinon.stub().returns([]);
     await render(hbs`

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -8,6 +8,8 @@ import { start } from 'ember-qunit';
 sinon.assert.pass = assertion => QUnit.assert.ok(true, assertion);
 sinon.assert.fail = assertion => QUnit.assert.ok(false, assertion);
 
+QUnit.testDone(() => sinon.restore());
+
 setApplication(Application.create(config.APP));
 
 start();


### PR DESCRIPTION
Prior to this change, it was possible for the handler to process multiple events in the same contextual run. This meant that if a validator used fetch() there would be multiple fetch() for each event triggered. This isn't ideal. Instead we ignore events while waiting on the first validator to complete.

Code should be awaiting anyway so a race condition between different values should not occur.
