### PR TITLE
Enhanced event management

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,27 +132,6 @@ To validate the form state on initial render and any time **any** of its depende
   }}>
 ```
 
-#### Example with `validator-update` event
-
-**This has been deprecated. See [watch argument](#example-with-watch-argument).**
-
-To validate the form state on initial render and any time its dependent arguments change, add the `'validator-update'` event to the list of events passed in via the `on` argument.
-
-```hbs
-  <input {{validity (fn this.matchTo this.match) on="change,validator-update"}}>
-```
-
-```js
-export default MyComponent extends Component {
-  @action
-  matchTo(match, { value }) {
-    return value === match ? [] : ['Must match exactly'];
-  }
-}
-```
-
-**Tip:** For Glimmer's tracking to work properly, make sure you reference each tracked property you intend to validate against unconditionally in your validation method.
-
 #### Example with select
 
 ```hbs

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -1,6 +1,12 @@
+import { assert } from '@ember/debug';
 import { modifier } from 'ember-modifier';
-import { validate, registerValidatable } from 'ember-validity-modifier/utils/validate';
 import { deprecate } from '@ember/application/deprecations';
+import {
+  validate,
+  isValidatable,
+  registerValidatable,
+  unregisterValidatable,
+} from 'ember-validity-modifier/utils/validate';
 
 const commaSeperate = s => s.split(',').map(i => i.trim()).filter(Boolean);
 const reduceValidators = async (validators, ...args) => {
@@ -28,6 +34,10 @@ export default modifier(function validity(
   validators,
   { watch = [], on: eventNames = 'change,input,blur' }
 ) {
+  assert(
+    'Only one validity modifier can be applied to an element',
+    !isValidatable(element),
+  );
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
   let validateHandler = async () => {
@@ -62,6 +72,7 @@ export default modifier(function validity(
       .exercise(() => validate(element));
   }
   return () => {
+    unregisterValidatable(element);
     element.removeEventListener('validate', validateHandler);
     autoValidationEvents.forEach(eventName => {
       element.removeEventListener(eventName, autoValidationHandler);

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
 import { modifier } from 'ember-modifier';
-import { deprecate } from '@ember/application/deprecations';
 import {
   isValidatable,
   registerValidatable,
@@ -39,7 +38,6 @@ export default modifier(function validity(
     'Only one validity modifier can be applied to an element',
     !isValidatable(element),
   );
-  let watchForValidatorUpdates = false;
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => updateValidity(element);
   let updateValidity = async (target) => {
@@ -56,28 +54,11 @@ export default modifier(function validity(
   };
   element.addEventListener('validate', validateHandler);
   autoValidationEvents.forEach(eventName => {
-    if (eventName === 'validator-update') {
-      watchForValidatorUpdates = true;
-      return;
-    }
     element.addEventListener(eventName, autoValidationHandler);
   });
   registerValidatable(element);
-  if (watchForValidatorUpdates) {
-    deprecate(
-      'Use "watch" argument instead of the "validator-update" event',
-      false,
-      {
-        id: 'ember-validity-modifier-validator-update',
-        url: 'https://github.com/sukima/ember-validity-modifier/#example-with-watch-argument',
-        until: '2.0.0'
-      }
-    );
-    updateValidity(element); // Do not await, allow unhandled errors
-  } else {
-    AutoTrackingExerciser.from(watch)
-      .exercise(() => updateValidity(element));
-  }
+  AutoTrackingExerciser.from(watch)
+    .exercise(() => updateValidity(element));
   return () => {
     unregisterValidatable(element);
     element.removeEventListener('validate', validateHandler);

--- a/addon/utils/validate.js
+++ b/addon/utils/validate.js
@@ -17,10 +17,14 @@ export function validate(...elements) {
   return Promise.all(elements.map(validateElement));
 }
 
+export function isValidatable(element) {
+  return validatables.has(element);
+}
+
 export function registerValidatable(element) {
   validatables.add(element);
 }
 
-export function isValidatable(element) {
-  return validatables.has(element);
+export function unregisterValidatable(element) {
+  validatables.delete(element);
 }

--- a/addon/utils/validate.js
+++ b/addon/utils/validate.js
@@ -1,15 +1,16 @@
 const validatables = new WeakSet();
 
 function validateElement(element) {
-  if (!isValidatable(element)) { return; }
-  let validateEvent = new CustomEvent('validate');
-  return new Promise(resolve => {
-    let handler = () => {
-      element.removeEventListener('validated', handler);
+  return new Promise((resolve, reject) => {
+    let eventDetail = { resolve, reject };
+    let validateEvent = new CustomEvent('validate', {
+      bubbles: true,
+      cancelable: true,
+      detail: eventDetail,
+    });
+    if (element.dispatchEvent(validateEvent)) {
       resolve();
-    };
-    element.addEventListener('validated', handler);
-    element.dispatchEvent(validateEvent);
+    }
   });
 }
 

--- a/tests/dummy/app/controllers/index-example.js
+++ b/tests/dummy/app/controllers/index-example.js
@@ -1,0 +1,45 @@
+import Controller from '@ember/controller';
+import User from 'dummy/models/user';
+import { action } from '@ember/object';
+import { validate } from 'ember-validity-modifier';
+import { tracked } from '@glimmer/tracking';
+import { next } from '@ember/runloop';
+
+export default class IndexExampleController extends Controller {
+  @tracked validationMessages = {};
+
+  @action
+  assignValidationMessages({ target }) {
+    target.dataset.state = 'dirty';
+    this.validationMessages = {
+      ...this.validationMessages,
+      [target.name]: target.validationMessage
+    };
+  }
+
+  @action
+  async handleFormSubmit(event) {
+    event.preventDefault();
+    let { target: form } = event;
+    await validate(...form.elements);
+    if (form .checkValidity()) {
+      this.createUser(Object.fromEntries(new FormData(form)));
+      this.resetForm(form);
+    }
+  }
+
+  createUser(data) {
+    this.model.addUser(new User(data));
+  }
+
+  resetForm(form) {
+    let elements = [...form.elements];
+    form.reset();
+    elements[0].focus();
+    next(() => {
+      elements.forEach(e => e.dataset.state = 'clean');
+      this.validationMessages = {};
+    });
+  }
+
+}

--- a/tests/dummy/app/helpers/validate-confirmation.js
+++ b/tests/dummy/app/helpers/validate-confirmation.js
@@ -1,0 +1,11 @@
+import Helper from '@ember/component/helper';
+
+const getElement = (id) => document.getElementById(id);
+
+export function validateConfirmation([passwordFieldId]) {
+  return ({ value }) => getElement(passwordFieldId).value === value
+    ? []
+    : ['Confirmation must match password'];
+}
+
+export default Helper.helper(validateConfirmation);

--- a/tests/dummy/app/helpers/validate-password.js
+++ b/tests/dummy/app/helpers/validate-password.js
@@ -1,0 +1,18 @@
+import Helper from '@ember/component/helper';
+
+export function validatePassword() {
+  return ({ value }) => {
+    let requirements = [
+      [/.{6,}/, 'Password must be at least six characters long.'],
+      [/[0-9]/, 'Password must contain at least one number.'],
+      [/[a-z]/, 'Password must contain at least one lowercase letter.'],
+      [/[A-Z]/, 'Password must contain at least one uppercase letter.'],
+      [/[^a-zA-Z0-9\s]/, 'Password must contain at least one special character.'],
+    ];
+    return requirements
+      .map(([predicate, message]) => predicate.test(value) ? null : message)
+      .filter(Boolean);
+  };
+}
+
+export default Helper.helper(validatePassword);

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -1,0 +1,12 @@
+import { tracked } from '@glimmer/tracking';
+
+export default class User {
+  @tracked name;
+  @tracked phone;
+  @tracked email;
+  @tracked password;
+
+  constructor(data = {}) {
+    Object.assign(this, data);
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,4 +7,5 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function() {
+  this.route('index-example', { path: '/' });
 });

--- a/tests/dummy/app/routes/index-example.js
+++ b/tests/dummy/app/routes/index-example.js
@@ -1,0 +1,26 @@
+import Route from '@ember/routing/route';
+import User from 'dummy/models/user';
+import { tracked } from '@glimmer/tracking';
+
+class IndexModel {
+  @tracked users = [];
+
+  addUser(user) {
+    this.users = [...this.users, user];
+  }
+}
+
+export default class IndexExampleRoute extends Route {
+
+  model() {
+    let model = new IndexModel();
+    model.addUser(new User({
+      name: 'Ralph Wreck-it',
+      phone: '555-1234',
+      email: 'ralph@fixitfelix.com',
+      password: 'foobar'
+    }));
+    return model;
+  }
+
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,82 @@
+:root {
+  --default-color: gainsboro;
+  --valid-color: lightgreen;
+  --invalid-color: salmon;
+  --required-color: salmon;
+}
+
+main {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+section {
+  min-width: 400px;
+  flex-basis: 100%;
+  flex: 1;
+}
+
+h1, h2 {
+  text-align: center;
+}
+
+form {
+  display: grid;
+  grid: auto-flow / 1fr 2fr;
+  column-gap: 1rem;
+  max-width: 600px;
+}
+
+label {
+  text-align: right;
+}
+
+input, button {
+  border: thin solid black;
+  border-radius: 0.2rem;
+  padding: 0.2rem;
+}
+
+button {
+  background-color: var(--default-color);
+}
+
+[data-state=dirty]:valid {
+  border-color: var(--valid-color);
+}
+
+[data-state=dirty]:invalid {
+  border-color: var(--invalid-color);
+}
+
+form > label {
+  grid-column: 1 / 2;
+}
+
+form > button,
+form > .validation-message {
+  grid-column: 2 / 3;
+}
+
+form > .full-width {
+  grid-column: 1 / 3;
+}
+
+.validation-message {
+  text-align: right;
+  margin-bottom: 0.1rem;
+  color: salmon;
+}
+
+.validation-message:empty {
+  margin-bottom: 1.3rem;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.required {
+  color: var(--required-color);
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,7 @@
-<h2 id="title">Welcome to Ember</h2>
+<header>
+  <h2 id="title">ember-validity-modifier</h2>
+</header>
 
-{{outlet}}
+<main>
+  {{outlet}}
+</main>

--- a/tests/dummy/app/templates/index-example.hbs
+++ b/tests/dummy/app/templates/index-example.hbs
@@ -1,0 +1,54 @@
+<section>
+  <h1>Create a new user</h1>
+  <form
+    id="userForm"
+    novalidate
+    {{on "validated" this.assignValidationMessages}}
+    {{on "submit" this.handleFormSubmit}}
+  >
+    <div class="full-width text-right"><sup class="required">*</sup> Required</div>
+
+    <label for="userForm-name">Name<sup class="required">*</sup></label>
+    <input id="userForm-name" name="name" required {{validity}}>
+    <span class="validation-message">{{this.validationMessages.name}}</span>
+
+    <label for="userForm-phone">Phone</label>
+    <input id="userForm-phone" name="phone" type="tel" {{validity}}>
+    <span class="validation-message">{{this.validationMessages.phone}}</span>
+
+    <label for="userForm-email">Email<sup class="required">*</sup></label>
+    <input id="userForm-email" name="email" type="email" required {{validity}}>
+    <span class="validation-message">{{this.validationMessages.email}}</span>
+
+    <label for="userForm-password">Password<sup class="required">*</sup></label>
+    <input
+      id="userForm-password"
+      name="password"
+      type="password"
+      required
+      {{validity (validate-password)}}
+    >
+    <span class="validation-message">{{this.validationMessages.password}}</span>
+
+    <label for="userForm-confirm">Confirm password<sup class="required">*</sup></label>
+    <input
+      id="userForm-confirm"
+      name="confirm"
+      type="password"
+      required
+      {{validity (validate-confirmation "userForm-password")}}
+    >
+    <span class="validation-message">{{this.validationMessages.confirm}}</span>
+
+    <button type="submit">Create</button>
+  </form>
+</section>
+
+<section>
+  <h1>Valid submissions</h1>
+  <ul id="userList">
+    {{#each @model.users as |user|}}
+      <li>"{{user.name}}" &lt;{{user.email}}&gt; &mdash; {{user.phone}}</li>
+    {{/each}}
+  </ul>
+</section>

--- a/tests/helpers/wait-for-validated.js
+++ b/tests/helpers/wait-for-validated.js
@@ -1,4 +1,4 @@
-const validatables = new WeakMap();
+const assignedDeferreds = new WeakMap();
 
 function createDeferred() {
   let resolve;
@@ -8,17 +8,18 @@ function createDeferred() {
 
 export function validatable(element) {
   element.addEventListener('validated', event => {
-    if (!validatables.has(element)) {
-      validatables.set(element, createDeferred());
+    if (!assignedDeferreds.has(element)) {
+      assignedDeferreds.set(element, createDeferred());
     }
-    validatables.get(element).resolve(event);
+    assignedDeferreds.get(element).resolve(event);
+    assignedDeferreds.delete(element);
   });
   return element;
 }
 
 export function waitForValidated(element) {
-  if (!validatables.has(element)) {
-    validatables.set(element, createDeferred());
+  if (!assignedDeferreds.has(element)) {
+    assignedDeferreds.set(element, createDeferred());
   }
-  return validatables.get(element).promise;
+  return assignedDeferreds.get(element).promise;
 }

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -167,25 +167,6 @@ module('Integration | Modifier | validity', function(hooks) {
     sinon.assert.calledOnce(this.testValidator);
   });
 
-  test('validates on initial render if validator-update is present in list of events', async function() {
-    this.testValidator = sinon.stub().returns([]);
-    await render(hbs`<input {{validity this.testValidator on="validator-update"}}>`);
-    sinon.assert.calledOnce(this.testValidator);
-  });
-
-  test('validates if validator-update event is present and arguments change', async function() {
-    this.testValidator = sinon.stub().returns([]);
-    this.set('match', 'foo');
-    await render(hbs`<input {{validity (fn this.testValidator this.match) on="validator-update,change"}}>`);
-    sinon.assert.calledOnce(this.testValidator);
-    sinon.assert.calledWith(this.testValidator, 'foo');
-    await this.set('match', 'foo-bar');
-    sinon.assert.calledTwice(this.testValidator);
-    sinon.assert.calledWith(this.testValidator, 'foo-bar');
-    await fillIn('input', 'foo-bar');
-    sinon.assert.calledThrice(this.testValidator);
-  });
-
   test('validates on initial render if watch is true', async function() {
     this.testValidator = sinon.stub().returns([]);
     await render(hbs`<input {{validity this.testValidator on="" watch=true}}>`);

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -27,6 +27,21 @@ module('Integration | Modifier | validity', function(hooks) {
     assert.strictEqual(subject.validationMessage, '');
   });
 
+  test('supports wrapped inputs', async function(assert) {
+    this.testValidator = sinon.stub().returns([]);
+    await render(hbs`
+      <div {{validity this.testValidator on=""}}>
+        <input>
+      </div>
+    `);
+    let subject = find('input');
+    await validate(subject);
+    sinon.assert.calledOnce(this.testValidator);
+    sinon.assert.calledWith(this.testValidator, subject);
+    assert.ok(subject.validity.valid, 'expected validity to be valid');
+    assert.strictEqual(subject.validationMessage, '');
+  });
+
   test('prevents multiple modifiers on a single element', async function() {
     let onErrorSpy = sinon.spy();
     this.testValidator = sinon.stub().returns([]);

--- a/tests/integration/modifiers/validity-test.js
+++ b/tests/integration/modifiers/validity-test.js
@@ -140,6 +140,21 @@ module('Integration | Modifier | validity', function(hooks) {
     assert.equal(subject.validationMessage, 'test-invalid');
   });
 
+  test('flattens multiple events in same validation execution', async function() {
+    let waitForValidations = new Promise(resolve => {
+      this.testValidator = sinon.stub().callsFake(() => (resolve(), []));
+    });
+    await render(hbs`<input {{validity this.testValidator on=""}}>`);
+    let subject = find('input');
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    subject.dispatchEvent(new CustomEvent('validate'));
+    await waitForValidations;
+    sinon.assert.calledOnce(this.testValidator);
+  });
+
   test('auto validates on DOM events', async function() {
     this.testValidator = sinon.stub().returns([]);
     await render(hbs`<input {{validity this.testValidator on="change"}}>`);

--- a/tests/integration/utils/validate-test.js
+++ b/tests/integration/utils/validate-test.js
@@ -50,20 +50,4 @@ module('Integration | Utility | validate', function(hooks) {
     sinon.assert.alwaysCalledWith(this.validateSpy, sinon.match.has('type', 'validate'));
   });
 
-  test(`skips validation of non modified elements`, async function() {
-    this.validateSpy = sinon.spy();
-    await render(hbs`
-      <input {{on "validate" this.validateSpy}} {{validatable}}>
-      <input {{on "validate" this.validateSpy}}>
-      <input {{on "validate" this.validateSpy}}>
-    `);
-    let subjects = findAll('input');
-    let resultPromise = validate(...subjects);
-    let validatedEvent = new CustomEvent('validated');
-    subjects.forEach(i => i.dispatchEvent(validatedEvent));
-    await resultPromise;
-    sinon.assert.calledOnce(this.validateSpy);
-    sinon.assert.alwaysCalledWith(this.validateSpy, sinon.match.has('type', 'validate'));
-  });
-
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,8 +5,10 @@ import sinon from 'sinon';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
-sinon.assert.pass = assertion => QUnit.assert.ok(true, assertion);
-sinon.assert.fail = assertion => QUnit.assert.ok(false, assertion);
+sinon.assert.pass = (assertion) => QUnit.assert.ok(true, assertion);
+sinon.assert.fail = (assertion) => QUnit.assert.ok(false, assertion);
+
+QUnit.testDone(() => sinon.restore());
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
**This PR depends on #11 and its release update.**

This PR _should_ also fix #7 and #8

Prior to this change, we were bound to have the modifier be only used on the input element as on other elements would remove it from the easy use of `validate()`.

But because events can bubble it is possible that wrapping elements can respond to the event instead.

We also relied on the validated event to perform promise resolution.

This change fixes the awkward validate/validated event dance which freed us from tying the event dispatch to only elements registered as validatable and could be any element even those who capture a bubbled event.

This will help in cases where some form components might not place the `...attributes` on the actual input element.

## Example

If we had a `<FancyTextField>` component like this our validity modifier would not work. With this PR it does work.

```hbs
<div class="fancy-text-field" ...attributes>
  <input type="text" name=@name value=@value {{on "input" @update}}>
</div>
```

```hbs
<FancyTextField
  @name="foo"
  @value={{this.foo}}
  @update={{this.updateFooValue}}
  {{validity this.validateFoo}}
/>
```

This PR also moves `validator-update` to the `watch=` argument.

#### Before

```hbs
<input {{validity (fn this.validator this.foo) on="validator-update,change"}}>
```

#### After

```hbs
<input {{validity (fn this.validator this.foo) on="change" watch=this.foo}}>
```