### PR TITLE
Add watch= argument to deprecate validator-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,41 @@ export default class MyForm extends Component {
 }
 ```
 
+#### Example with `watch` argument
+
+To validate the form state on initial render add the `'watch'` argument with the value `true`.
+
+```hbs
+  <input {{validity
+    (fn this.matchTo this.match)
+    on="change"
+    watch=true
+  }}>
+```
+
+To validate the form state on initial render and any time **one** of its dependent arguments change, add the `'watch'` argument with the dependent property.
+
+```hbs
+  <input {{validity
+    (fn this.matchTo this.match)
+    on="change"
+    watch=this.match
+  }}>
+```
+
+To validate the form state on initial render and any time **any** of its dependent arguments change, add the `'watch'` argument using the `array` helper and a list of dependent properties.
+
+```hbs
+  <input {{validity
+    (fn this.matchTo this.match1 this.match2)
+    on="change"
+    watch=(array this.match1 this.macth2)
+  }}>
+```
+
 #### Example with `validator-update` event
+
+**This has been deprecated. See [watch argument](#example-with-watch-argument).**
 
 To validate the form state on initial render and any time its dependent arguments change, add the `'validator-update'` event to the list of events passed in via the `on` argument.
 

--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -1,5 +1,6 @@
 import { modifier } from 'ember-modifier';
 import { validate, registerValidatable } from 'ember-validity-modifier/utils/validate';
+import { deprecate } from '@ember/application/deprecations';
 
 const commaSeperate = s => s.split(',').map(i => i.trim()).filter(Boolean);
 const reduceValidators = async (validators, ...args) => {
@@ -7,10 +8,25 @@ const reduceValidators = async (validators, ...args) => {
   return errors.reduce((a, b) => [...a, ...b], []);
 };
 
+class AutoTrackingExerciser {
+  constructor(props) {
+    this.props = props;
+  }
+  exercise(callback) {
+    this.props.forEach(i => i);
+    if (this.props.length) { callback(); }
+  }
+  static from(maybeProps) {
+    return Array.isArray(maybeProps)
+      ? new AutoTrackingExerciser(maybeProps)
+      : new AutoTrackingExerciser([maybeProps]);
+  }
+}
+
 export default modifier(function validity(
   element,
   validators,
-  { on: eventNames = 'change,input,blur' }
+  { watch = [], on: eventNames = 'change,input,blur' }
 ) {
   let autoValidationEvents = commaSeperate(eventNames);
   let autoValidationHandler = () => validate(element);
@@ -31,7 +47,19 @@ export default modifier(function validity(
   });
   registerValidatable(element);
   if (watchForValidatorUpdates) {
+    deprecate(
+      'Use "watch" argument instead of the "validator-update" event',
+      false,
+      {
+        id: 'ember-validity-modifier-validator-update',
+        url: 'https://github.com/sukima/ember-validity-modifier/#example-with-watch-argument',
+        until: '2.0.0'
+      }
+    );
     validate(element);
+  } else {
+    AutoTrackingExerciser.from(watch)
+      .exercise(() => validate(element));
   }
   return () => {
     element.removeEventListener('validate', validateHandler);


### PR DESCRIPTION
Prior to this change, we mixed a virtual event validator-update to help track properties. This works currently because the validation workflow allows ember to exercise the validator and consume tracked properties.

We will be doing a big refactoring which will break this assumption requiring better and more explicit control on dependent properties.

This change introduces a new API and deprecates the old one. It will be a step towards the 2.0.0 release.

This PR should precede #10 