### PR TITLE
fix: Add { eager: false } to modifier functions

### DIFF
--- a/addon/modifiers/validity.js
+++ b/addon/modifiers/validity.js
@@ -21,4 +21,4 @@ export default modifier(function (
     .exercise(() => validate(...ValidityWalker.for(element)));
 
   return teardown;
-});
+}, { eager: false });

--- a/addon/modifiers/verify-form-validity.js
+++ b/addon/modifiers/verify-form-validity.js
@@ -3,4 +3,4 @@ import { verifyFormValidity } from '../-private/validity';
 
 export default modifier(function (element, _, options) {
   return verifyFormValidity(element, options);
-});
+}, { eager: false });


### PR DESCRIPTION
Until 4.0. Calling `modifier()` without an options argument is deprecated. It is supported until 4.0 so that existing modifiers can be migrated individually.

This leverages the deprecation warning's instructions to provide the modifier function with `{ eager: false }`.

Deprecation warning:
https://github.com/ember-modifier/ember-modifier/commit/b6624f8d7c6f786f681038784ead9f7b16c6d8f5#diff-96b48680d573c4d45b2971736d8c1ac2afb92c8c63b88047ff6cb423c1d784ecL50-L53

Fixes:
https://github.com/sukima/ember-validity-modifier/issues/17